### PR TITLE
OSW-851: Add sqlalchemy pool_pre_ping option to avoid idle connections + package configuration updates.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
           key: tox-${{ hashFiles('requirements/*.txt') }}-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('.pre-commit-config.yaml') }}
 
       - name: Run tox
-        run: tox -e lint,py,coverage-report,typing  # run tox using Python in path
+        run: tox -e lint,py,coverage-report  # run tox using Python in path
 
   build:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,17 +1,10 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v4.4.0
     hooks:
       - id: check-yaml
       - id: check-toml
 
-  - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
-    hooks:
-      - id: isort
-        name: isort (python)
-        additional_dependencies:
-          - toml
 
   - repo: https://github.com/psf/black
     rev: 23.3.0
@@ -19,6 +12,18 @@ repos:
       - id: black
 
   - repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
+    rev: 7.0.0
     hooks:
       - id: flake8
+
+  - repo: https://github.com/pycqa/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
+        additional_dependencies:
+          - toml
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.2.0
+    hooks:
+      - id: mypy

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,17 @@
 Change Log
 ==========
 
+0.7.1
+-----
+
+* Added sqlalchemy pool_pre_ping option to avoid idle connections and made package configuration updates.
+
+0.7.0
+-----
+
+* Added new components_json field to the jira_fields table.
+* Moved image push from public lsstsqre dockerhub to lsst-ts GHCR.
+
 0.6.1
 -----
 

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -2,10 +2,12 @@ import asyncio
 import logging
 from logging.config import fileConfig
 
-from sqlalchemy import engine_from_config, inspect, pool
+from sqlalchemy import engine, engine_from_config, inspect, pool
 from sqlalchemy.ext.asyncio import AsyncEngine
 
-from alembic import context
+# Use type: ignore because alembic.context is only available for env.py
+# when it is executed through the alembic command.
+from alembic import context  # type: ignore
 from narrativelog.shared_state import create_db_url
 
 # This is the Alembic Config object, which provides
@@ -30,7 +32,7 @@ target_metadata = None
 # ... etc.
 
 
-def do_run_migrations(connection):
+def do_run_migrations(connection: engine.base.Connection) -> None:
     """Run a migration given an async connection.
 
     A helper function used by run_migrations_online.
@@ -48,7 +50,7 @@ def do_run_migrations(connection):
         context.run_migrations(log=log, table_names=table_names)
 
 
-async def run_migrations_online():
+async def run_migrations_online() -> None:
     """Run migrations in 'online' mode.
 
     In this scenario we need to create an Engine

--- a/alembic/versions/49ef39173f83_add_components_json_field_to_jira_.py
+++ b/alembic/versions/49ef39173f83_add_components_json_field_to_jira_.py
@@ -9,7 +9,9 @@ import logging
 
 import sqlalchemy as sa
 
-from alembic import op
+# Use type: ignore because alembic.context is only available for env.py
+# when it is executed through the alembic command.
+from alembic import op  # type: ignore
 
 # revision identifiers, used by Alembic.
 revision = "49ef39173f83"

--- a/alembic/versions/54f755dbdb6f_add_category_and_time_lost_type_.py
+++ b/alembic/versions/54f755dbdb6f_add_category_and_time_lost_type_.py
@@ -10,7 +10,9 @@ import logging
 import sqlalchemy as sa
 import sqlalchemy.types as saty
 
-from alembic import op
+# Use type: ignore because alembic.context is only available for env.py
+# when it is executed through the alembic command.
+from alembic import op  # type: ignore
 
 # revision identifiers, used by Alembic.
 revision = "54f755dbdb6f"

--- a/alembic/versions/b631d21eb6dc_add_date_end_and_rename_date_user_.py
+++ b/alembic/versions/b631d21eb6dc_add_date_end_and_rename_date_user_.py
@@ -10,7 +10,9 @@ import logging
 import sqlalchemy as sa
 import sqlalchemy.types as saty
 
-from alembic import op
+# Use type: ignore because alembic.context is only available for env.py
+# when it is executed through the alembic command.
+from alembic import op  # type: ignore
 
 # revision identifiers, used by Alembic.
 revision = "b631d21eb6dc"

--- a/alembic/versions/c5780561f83b_add_columns_systems_subsystems_cscs.py
+++ b/alembic/versions/c5780561f83b_add_columns_systems_subsystems_cscs.py
@@ -9,7 +9,9 @@ import logging
 import sqlalchemy as sa
 import sqlalchemy.types as saty
 
-from alembic import op
+# Use type: ignore because alembic.context is only available for env.py
+# when it is executed through the alembic command.
+from alembic import op  # type: ignore
 
 # revision identifiers, used by Alembic.
 revision = "c5780561f83b"

--- a/alembic/versions/d9606992ad8d_update_message_table_systems_subsystems_.py
+++ b/alembic/versions/d9606992ad8d_update_message_table_systems_subsystems_.py
@@ -7,7 +7,9 @@ Create Date: 2023-09-11 17:44:07.705399
 """
 import logging
 
-from alembic import op
+# Use type: ignore because alembic.context is only available for env.py
+# when it is executed through the alembic command.
+from alembic import op  # type: ignore
 
 # revision identifiers, used by Alembic.
 revision = "d9606992ad8d"
@@ -18,7 +20,7 @@ depends_on = None
 MESSAGE_TABLE_NAME = "message"
 
 
-def upgrade(log: logging.Logger, table_names: set[str]):
+def upgrade(log: logging.Logger, table_names: set[str]) -> None:
     if MESSAGE_TABLE_NAME not in table_names:
         log.info(f"No {MESSAGE_TABLE_NAME} table; nothing to do")
         return
@@ -29,7 +31,7 @@ def upgrade(log: logging.Logger, table_names: set[str]):
     op.alter_column(MESSAGE_TABLE_NAME, "cscs", nullable=True)
 
 
-def downgrade(log: logging.Logger, table_names: set[str]):
+def downgrade(log: logging.Logger, table_names: set[str]) -> None:
     if MESSAGE_TABLE_NAME not in table_names:
         log.info(f"No {MESSAGE_TABLE_NAME} table; nothing to do")
         return

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,59 +8,6 @@ build-backend = 'setuptools.build_meta'
 
 [tool.setuptools_scm]
 
-[tool.tox]
-legacy_tox_ini = """
-[tox]
-envlist = py310,coverage-report,typing,lint
-isolated_build = True
-
-[testenv]
-description = Run pytest against {envname}.
-deps =
-    -r{toxinidir}/requirements/main.txt
-    -r{toxinidir}/requirements/dev.txt
-commands =
-    coverage run -m pytest {posargs}
-passenv =
-    # Basic configuration
-    NARRATIVELOG_DB_USER
-    NARRATIVELOG_DB_PASSWORD
-    NARRATIVELOG_DB_HOST
-    NARRATIVELOG_DB_PORT
-    NARRATIVELOG_DB_DATABASE
-    SITE_ID
-setenv =
-    # Silence warning about ignoring PYTHONPATH.
-    PYTHONPATH=
-
-[testenv:coverage-report]
-description = Compile coverage from each test run.
-skip_install = true
-deps = coverage[toml]>=5.0.2
-depends =
-    py310
-commands =
-    coverage combine
-    coverage report
-
-[testenv:typing]
-description = Run mypy.
-commands =
-    mypy src/narrativelog tests setup.py
-
-[testenv:lint]
-description = Lint codebase by running pre-commit (Black, isort, Flake8).
-skip_install = true
-deps =
-    pre-commit
-commands = pre-commit run --all-files
-
-[testenv:run]
-description = Run the development server with auto-reload for code changes.
-usedevelop = true
-commands = uvicorn narrativelog.app:app --reload
-"""
-
 [tool.coverage.run]
 parallel = true
 branch = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,20 +1,19 @@
 [metadata]
 name = narrativelog
 description = Observatory Wide Logbook.
-author = University of Washington
-author_email = sqre-admin@lists.lsst.org
+author = Vera C. Rubin Observatory Software
+author_email = saranda@lsst.org
 long_description = file: README.rst, CHANGELOG.rst, LICENSE
 long_description_content_type = text/x-rst
-url = https://github.com/lsst-sqre/narrativelog
+url = https://github.com/lsst-ts/narrativelog
 project_urls =
-    Change log = https://github.com/lsst-sqre/narrativelog/master/blob/CHANGELOG.rst
-    Source code = https://github.com/lsst-sqre/narrativelog
-    Issue tracker = https://github.com/lsst-sqre/narrativelog/issues
+    Change log = https://github.com/lsst-ts/narrativelog/master/blob/CHANGELOG.rst
+    Source code = https://github.com/lsst-ts/narrativelog
+    Issue tracker = https://github.com/lsst-ts/narrativelog/issues
 classifiers =
     Development Status :: 4 - Beta
     License :: OSI Approved :: MIT License
     Programming Language :: Python
-    Programming Language :: Python :: 3
     Programming Language :: Python :: 3.10
     Natural Language :: English
     Operating System :: POSIX
@@ -30,16 +29,12 @@ packages=find:
 python_requires = >=3.10
 setup_requires =
     setuptools_scm
-# Use requirements/main.in for runtime dependencies instead of install_requires
 
 [options.packages.find]
 where = src
 
-[options.entry_points]
-console_scripts =
-    narrativelog = narrativelog.cli:main
-
 [tool:pytest]
+asyncio_mode = auto
 # Ignore ndarray size changed warnings (also hide dtype and ufunc warnings because they are common,
 # based on https://github.com/numpy/numpy/pull/432).
 # I borrowed the technique from astropy:
@@ -50,7 +45,8 @@ filterwarnings =
     ignore:numpy.ufunc size changed:RuntimeWarning
 
 [flake8]
-# match black
+# Give flake8 some margin above black's line-length (79)
+# Black doesn't always format lines to be exactly under the limit
 max-line-length = 88
 # E203: whitespace before :, flake8 disagrees with PEP-8
 # W503: line break after binary operator, flake8 disagrees with PEP-8

--- a/src/narrativelog/log_message_database.py
+++ b/src/narrativelog/log_message_database.py
@@ -34,7 +34,9 @@ class LogMessageDatabase:
         self.logger = structlog.get_logger("LogMessageDatabase")
         sa_url = sqlalchemy.engine.make_url(url)
         sa_url = sa_url.set(drivername="postgresql+asyncpg")
-        self.engine = create_async_engine(sa_url, future=True)
+        self.engine = create_async_engine(
+            sa_url, future=True, pool_pre_ping=True
+        )
         self.message_table = message_table
         self.jira_fields_table = jira_fields_table
         self.start_task = asyncio.create_task(self.start())

--- a/src/narrativelog/shared_state.py
+++ b/src/narrativelog/shared_state.py
@@ -4,7 +4,7 @@ __all__ = ["create_shared_state", "delete_shared_state", "get_shared_state"]
 
 import logging
 import os
-import urllib
+import urllib.parse
 
 import sqlalchemy as sa
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,46 @@
+[tox]
+envlist = py310,coverage-report,lint
+isolated_build = True
+
+[testenv]
+description = Run pytest against {envname}.
+deps =
+    -r{toxinidir}/requirements/main.txt
+    -r{toxinidir}/requirements/dev.txt
+commands =
+    coverage run -m pytest {posargs}
+passenv =
+    # Basic configuration
+    PGUSER
+    PGPASSWORD
+    NARRATIVELOG_DB_USER
+    NARRATIVELOG_DB_PASSWORD
+    NARRATIVELOG_DB_HOST
+    NARRATIVELOG_DB_PORT
+    NARRATIVELOG_DB_DATABASE
+    SITE_ID
+setenv =
+    # Silence warning about ignoring PYTHONPATH.
+    PYTHONPATH=
+
+[testenv:coverage-report]
+description = Compile coverage from each test run.
+skip_install = true
+deps = coverage[toml]>=5.0.2
+depends =
+    py310
+commands =
+    coverage combine
+    coverage report
+
+[testenv:lint]
+description = Lint codebase by running pre-commit (black, isort, flake8, mypy).
+skip_install = true
+deps =
+    pre-commit
+commands = pre-commit run --all-files
+
+[testenv:run]
+description = Run the development server with auto-reload for code changes.
+usedevelop = true
+commands = uvicorn narrativelog.main:app --reload


### PR DESCRIPTION
This PR was originally just for adding the `pool_pre_ping` to the sqlalchemy `create_async_engine` in order to improve the behavior for idle connections.

Additionaly package configurations were updated as recent Github jobs started failing. Eventually we should integrate the TSSW pipelines: [OSW-1211](https://rubinobs.atlassian.net/browse/OSW-1211).

[OSW-1211]: https://rubinobs.atlassian.net/browse/OSW-1211?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ